### PR TITLE
Handle funky address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby "2.1.5"
+ruby "2.1.10"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.0'

--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -20,7 +20,7 @@ module DonationsHelper
         where_clause = "(volunteers.id = '#{object.id}') AND (donations.volunteer_id = volunteers.id) AND (donations.donation_type_id = donation_types.id) and (donation_types.non_monetary = FALSE)"
       else
         address_hash = (object.address.to_s + object.city.to_s).gsub(/[^0-9a-zA-Z]/,"").downcase
-        where_clause = "(LOWER(regexp_replace(volunteers.address || volunteers.city, '[^0-9a-zA-Z]', '')) = '" + address_hash + "') AND (donations.volunteer_id = volunteers.id) AND (donations.donation_type_id = donation_types.id) and (donation_types.non_monetary = FALSE)"
+        where_clause = "(REGEXP_REPLACE(LOWER(volunteers.address || volunteers.city), '[^0-9a-z]', '', 'g') = '" + address_hash + "') AND (donations.volunteer_id = volunteers.id) AND (donations.donation_type_id = donation_types.id) and (donation_types.non_monetary = FALSE)"
       end
 
       # join = "INNER JOIN workday_#{@objectName}s ON workday_#{@objectName}s.workday_id = workdays.id"

--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -19,8 +19,8 @@ module DonationsHelper
       if (object.address.to_s.empty? && object.city.to_s.empty?)
         where_clause = "(volunteers.id = '#{object.id}') AND (donations.volunteer_id = volunteers.id) AND (donations.donation_type_id = donation_types.id) and (donation_types.non_monetary = FALSE)"
       else
-        address_hash = (object.address.to_s + object.city.to_s).gsub(/\s+/,"").downcase
-        where_clause = "(LOWER(TRANSLATE(volunteers.address || volunteers.city, ' ', '')) = '" + address_hash + "') AND (donations.volunteer_id = volunteers.id) AND (donations.donation_type_id = donation_types.id) and (donation_types.non_monetary = FALSE)"
+        address_hash = (object.address.to_s + object.city.to_s).gsub(/[^0-9a-zA-Z]/,"").downcase
+        where_clause = "(LOWER(regexp_replace(volunteers.address || volunteers.city, '[^0-9a-zA-Z]', '')) = '" + address_hash + "') AND (donations.volunteer_id = volunteers.id) AND (donations.donation_type_id = donation_types.id) and (donation_types.non_monetary = FALSE)"
       end
 
       # join = "INNER JOIN workday_#{@objectName}s ON workday_#{@objectName}s.workday_id = workdays.id"

--- a/test/integration/volunteers_edit_test.rb
+++ b/test/integration/volunteers_edit_test.rb
@@ -175,14 +175,11 @@ class VolunteersEditTest < ActionDispatch::IntegrationTest
   end
 
   test "successful edit with funky address" do
-    address_save = @volunteer.address
     @volunteer.address = "D'Nure St & 5th @ Vine"
     @volunteer.save
     log_in_as(@user)
     get edit_volunteer_path(@volunteer)
     assert_template 'volunteers/edit'
-    @volunteer.address = volunteer_save
-    @volunteer.save
   end
 
   test "successful delete as admin" do

--- a/test/integration/volunteers_edit_test.rb
+++ b/test/integration/volunteers_edit_test.rb
@@ -174,12 +174,23 @@ class VolunteersEditTest < ActionDispatch::IntegrationTest
     assert_equal @volunteer.email, email
   end
 
-  test "successful edit with funky address" do
-    @volunteer.address = "D'Nure St & 5th @ Vine"
-    @volunteer.save
-    log_in_as(@user)
-    get edit_volunteer_path(@volunteer)
+  test "Find family donation with funky address" do
+    funky_address = "D'Nure St & 5th @ Vine"
+    funky_city = "L'odi"
+    @volunteer1 = volunteers(:volunteer_1)
+    @volunteer1.address = funky_address
+    @volunteer1.city = funky_city
+    @volunteer1.save
+    log_in_as(@monetary_donation_user)
+    get edit_volunteer_path(@volunteer1)
     assert_template 'volunteers/edit'
+    assert_no_match 'a[id=?]', "linkDonationSummary"
+    @volunteer.address = funky_address
+    @volunteer.city = funky_city
+    @volunteer.save
+    get edit_volunteer_path(@volunteer1)
+    assert_template 'volunteers/edit'
+    assert_select 'a[id=?]', "linkDonationSummary"
   end
 
   test "successful delete as admin" do

--- a/test/integration/volunteers_edit_test.rb
+++ b/test/integration/volunteers_edit_test.rb
@@ -174,6 +174,17 @@ class VolunteersEditTest < ActionDispatch::IntegrationTest
     assert_equal @volunteer.email, email
   end
 
+  test "successful edit with funky address" do
+    address_save = @volunteer.address
+    @volunteer.address = "D'Nure St & 5th @ Vine"
+    @volunteer.save
+    log_in_as(@user)
+    get edit_volunteer_path(@volunteer)
+    assert_template 'volunteers/edit'
+    @volunteer.address = volunteer_save
+    @volunteer.save
+  end
+
   test "successful delete as admin" do
     log_in_as(@admin)
     get edit_volunteer_path(@volunteer)


### PR DESCRIPTION
If a volunteer had an address with special characters in it, e.g. an apostrophe, this would cause a PSQL syntax error when it was comparing address hashes to find donations across a family. This prevented you from even getting into a volunteer record to edit it.